### PR TITLE
Update suggested action usage from v1 to v1.0.0 since tag does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: hrysd/action-php_codesniffer@v1
+      - uses: hrysd/action-php_codesniffer@v1.0.0
         with:
           github_token: ${{ secrets.github_token }}
           standard: PSR12


### PR DESCRIPTION
Update suggested action usage from v1 to v1.0.0 since tag does not exist

![image](https://user-images.githubusercontent.com/21138205/97442831-912e8d00-192a-11eb-8065-e41d90d4faa5.png)
